### PR TITLE
1、事件触发机制改进，变量isNewSession真正起作用，在新授权时为true  在已有数据时为false 都会触发事件

### DIFF
--- a/src/Middleware/OAuthAuthenticate.php
+++ b/src/Middleware/OAuthAuthenticate.php
@@ -12,6 +12,7 @@ use Overtrue\LaravelWechat\Events\WeChatUserAuthorized;
  */
 class OAuthAuthenticate
 {
+
     /**
      * Use Service Container would be much artisan.
      */
@@ -30,31 +31,55 @@ class OAuthAuthenticate
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
-     * @param string|null              $guard
+     * @param string                   $checkRange 使用范围,all:所有环境都要授权  weixin:只在微信浏览器中授权
+     * @param string                   $scopes 授权范围 公众平台（snsapi_userinfo / snsapi_base），开放平台：snsapi_login 不设置读取配制
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $guard = null)
+    public function handle($request, Closure $next, $checkRange = 'all', $scopes = null)
     {
-        $isNewSession = false;
+        //授权信息范围如果有参数以参数为准,否则以config为准,默认为snsapi_base
+        $scopes = $scopes ? [$scopes]: config('wechat.oauth.scopes', ['snsapi_base']);
 
-        if (!session('wechat.oauth_user')) {
-            if ($request->has('state') && $request->has('code')) {
-                session(['wechat.oauth_user' => $this->wechat->oauth->user()]);
-                $isNewSession = true;
-
-                return redirect()->to($this->getTargetUrl($request));
-            }
-
-            $scopes = config('wechat.oauth.scopes', ['snsapi_base']);
-
-            if (is_string($scopes)) {
-                $scopes = array_map('trim', explode(',', $scopes));
-            }
-
-            return $this->wechat->oauth->scopes($scopes)->redirect($request->fullUrl());
+        if (is_string($scopes)) {
+            $scopes = array_map('trim', explode(',', $scopes));
         }
 
+        //是否需要进行微信授权检查, all检查所有(只能在微信内访问) wexin(只在微信内检查,其它端忽略)
+        if($checkRange == 'all' || ($checkRange == 'wexin' && $this->isWexin($request))){
+
+            //获取授权信息条件
+            //  1:session为空
+            //  2:session中的授权信息为snsapi_base  本次是 snsapi_userinfo 需要重新获取
+            if (!session('wechat.oauth_user') ||
+                (session('wechat.oauth_user.original.scope','')=='snsapi_base' && in_array("snsapi_userinfo",$scopes))
+            ) {
+
+                # 第二步,如果拿到code 以code换取token并获取用户信息
+                if ($request->has('state') && $request->has('code')) {
+
+                    session(['wechat.oauth_user' => $this->wechat->oauth->user()]);
+
+                    $isNewSession = true;
+                    Event::fire(new WeChatUserAuthorized(session('wechat.oauth_user'), $isNewSession));
+
+                    return redirect()->to($this->getTargetUrl($request));
+                }
+
+                # 第一步:获取code 先清空session
+                session()->forget('wechat.oauth_user');
+                $scopes = config('wechat.oauth.scopes', ['snsapi_base']);
+
+                if (is_string($scopes)) {
+                    $scopes = array_map('trim', explode(',', $scopes));
+                }
+
+                return $this->wechat->oauth->scopes($scopes)->redirect($request->fullUrl());
+            }
+        }
+
+        //保留已
+        $isNewSession = false;
         Event::fire(new WeChatUserAuthorized(session('wechat.oauth_user'), $isNewSession));
 
         return $next($request);
@@ -72,5 +97,18 @@ class OAuthAuthenticate
         $queries = array_except($request->query(), ['code', 'state']);
 
         return $request->url().(empty($queries) ? '' : '?'.http_build_query($queries));
+    }
+
+    /**
+     * 判断是当前是否为微信浏览器
+     * @param $request
+     * @return bool
+     */
+    private function isWexin($request )
+    {
+        if (strpos($request->header('user_agent'), 'MicroMessenger') === false){
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
2、是否重新去微信获取授权信息条件增加为两个，一是session为空状态，二是当压史session中scopes==snsapi_base
当前为snsapi_userinfo时也要重新去微信授权，因为之提供的信息不一样
3、是否进行微信授权增加变量$checkRange
默认为all，意思在所有浏览器都要进行微信授权，意思就是这个页面只能在微信中打开。如果为wexin，则仅会在微信浏览器中去获取微信授权，非微信浏
览器可以不影响