### PR TITLE
完善中间件逻辑机制

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,16 @@ Route::group(['middleware' => ['web', 'wechat.oauth']], function () {
 ```
 _如果你在用 5.1 上面没有 'web' 中间件_
 
+当然，你也可以在中间件参数指定当前的 `scopes`:
+
+```php
+Route::group(['middleware' => ['web', 'wechat.oauth:snsapi_userinfo']], function () {
+  // ...
+});
+```
+
 上面的路由定义了 `/user` 是需要微信授权的，那么在这条路由的**回调 或 控制器对应的方法里**， 你就可以从 `session('wechat.oauth_user')` 拿到已经授权的用户信息了。
+
 
 ## 模拟授权
 
@@ -238,6 +247,15 @@ _如果你在用 5.1 上面没有 'web' 中间件_
 ```
 
 以上字段在 scope 为 `snsapi_userinfo` 时尽可能配置齐全哦，当然，如果你的模式只是 `snsapi_base` 的话只需要 `openid` 就好了。
+
+## 授权事件
+
+每次授权均会触发 `Overtrue\LaravelWechat\Events\WeChatUserAuthorized`，你可以监听该事件，该事件有两个属性：
+
+```php
+$event->user; // 同 session('wechat.oauth_user') 一样
+$event->isNewSession; // 是不是新的会话（第一次创建 session 时为 true）
+```
 
 更多 SDK 的具体使用请参考：https://easywechat.org
 

--- a/src/Middleware/OAuthAuthenticate.php
+++ b/src/Middleware/OAuthAuthenticate.php
@@ -31,7 +31,7 @@ class OAuthAuthenticate
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
-     * @param bool|false               $onlyRedirectInWeChatBrowser
+     * @param bool|null                $onlyRedirectInWeChatBrowser
      * @param string|null              $scopes
      *
      * @return mixed

--- a/src/Middleware/OAuthAuthenticate.php
+++ b/src/Middleware/OAuthAuthenticate.php
@@ -12,6 +12,7 @@ use Overtrue\LaravelWechat\Events\WeChatUserAuthorized;
  */
 class OAuthAuthenticate
 {
+
     /**
      * Use Service Container would be much artisan.
      */
@@ -30,31 +31,55 @@ class OAuthAuthenticate
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
-     * @param string|null              $guard
+     * @param string                   $checkRange 使用范围,all:所有环境都要授权  weixin:只在微信浏览器中授权
+     * @param string                   $scopes 授权范围 公众平台（snsapi_userinfo / snsapi_base），开放平台：snsapi_login 不设置读取配制
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $guard = null)
+    public function handle($request, Closure $next, $checkRange = 'all', $scopes = null)
     {
-        $isNewSession = false;
+        //授权信息范围如果有参数以参数为准,否则以config为准,默认为snsapi_base
+        $scopes = $scopes ? [$scopes]: config('wechat.oauth.scopes', ['snsapi_base']);
 
-        if (!session('wechat.oauth_user')) {
-            if ($request->has('state') && $request->has('code')) {
-                session(['wechat.oauth_user' => $this->wechat->oauth->user()]);
-                $isNewSession = true;
-
-                return redirect()->to($this->getTargetUrl($request));
-            }
-
-            $scopes = config('wechat.oauth.scopes', ['snsapi_base']);
-
-            if (is_string($scopes)) {
-                $scopes = array_map('trim', explode(',', $scopes));
-            }
-
-            return $this->wechat->oauth->scopes($scopes)->redirect($request->fullUrl());
+        if (is_string($scopes)) {
+            $scopes = array_map('trim', explode(',', $scopes));
         }
 
+        //是否需要进行微信授权检查, all检查所有(只能在微信内访问) wexin(只在微信内检查,其它端忽略)
+        if($checkRange == 'all' || ($checkRange == 'wexin' && $this->isWexin($request))){
+
+            //获取授权信息条件
+            //  1:session为空
+            //  2:session中的授权信息为snsapi_base  本次是 snsapi_userinfo 需要重新获取
+            if (!session('wechat.oauth_user') ||
+                (session('wechat.oauth_user.original.scope','')=='snsapi_base' && in_array("snsapi_userinfo",$scopes))
+            ) {
+
+                # 第二步,如果拿到code 以code换取token并获取用户信息
+                if ($request->has('state') && $request->has('code')) {
+
+                    session(['wechat.oauth_user' => $this->wechat->oauth->user()]);
+
+                    $isNewSession = true;
+                    Event::fire(new WeChatUserAuthorized(session('wechat.oauth_user'), $isNewSession));
+
+                    return redirect()->to($this->getTargetUrl($request));
+                }
+
+                # 第一步:获取code 先清空session
+                session()->forget('wechat.oauth_user');
+                $scopes = config('wechat.oauth.scopes', ['snsapi_base']);
+
+                if (is_string($scopes)) {
+                    $scopes = array_map('trim', explode(',', $scopes));
+                }
+
+                return $this->wechat->oauth->scopes($scopes)->redirect($request->fullUrl());
+            }
+        }
+
+        //保留已
+        $isNewSession = false;
         Event::fire(new WeChatUserAuthorized(session('wechat.oauth_user'), $isNewSession));
 
         return $next($request);
@@ -72,5 +97,18 @@ class OAuthAuthenticate
         $queries = array_except($request->query(), ['code', 'state']);
 
         return $request->url().(empty($queries) ? '' : '?'.http_build_query($queries));
+    }
+
+    /**
+     * 判断是当前是否为微信浏览器
+     * @param $request
+     * @return bool
+     */
+    private function isWexin($request )
+    {
+        if (strpos($request->header('user_agent'), 'MicroMessenger') === false){
+            return false;
+        }
+        return true;
     }
 }

--- a/src/config.php
+++ b/src/config.php
@@ -36,10 +36,12 @@ return [
     /*
      * OAuth 配置
      *
+     * only_wechat_browser: 只在微信浏览器跳转
      * scopes：公众平台（snsapi_userinfo / snsapi_base），开放平台：snsapi_login
      * callback：OAuth授权完成后的回调页地址(如果使用中间件，则随便填写。。。)
      */
     // 'oauth' => [
+    //     'only_wechat_browser' => false,
     //     'scopes'   => array_map('trim', explode(',', env('WECHAT_OAUTH_SCOPES', 'snsapi_userinfo'))),
     //     'callback' => env('WECHAT_OAUTH_CALLBACK', '/examples/oauth_callback.php'),
     // ],


### PR DESCRIPTION
onlyRedirectInWeChatBrowser 这个参数我看超哥没用起来。我的思路是这个可以中间件一个参数，如果用户有在中间件里传就以用户为准，默认以config中为准。然后在是不是要在非微信浏览器中授权跳转，你只是判断了浏览是不是微信，不是微信直接不授权跳过，应该是要和这个变量一起判断，应该是 $onlyRedirectInWeChatBrowser && !$this->isWeChatBrowser() 这个条件成立才会跳过，谢谢