### PR TITLE
修正配置文件加载失败问题

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -69,6 +69,8 @@ class ServiceProvider extends LaravelServiceProvider
      */
     public function register()
     {
+        $this->setupConfig();
+        
         $apps = [
             'official_account' => OfficialAccount::class,
             'work' => Work::class,

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,8 +34,6 @@ class ServiceProvider extends LaravelServiceProvider
      */
     public function boot()
     {
-        $this->setupConfig();
-
         if (config('wechat.route.enabled')) {
             $this->registerRoutes();
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -68,7 +68,7 @@ class ServiceProvider extends LaravelServiceProvider
     public function register()
     {
         $this->setupConfig();
-        
+
         $apps = [
             'official_account' => OfficialAccount::class,
             'work' => Work::class,


### PR DESCRIPTION
ServiceProvider 中方法执行顺序是 先 register 后 boot，所以应该在 register 里加载 config 文件，否则 register 会在 if (empty(config('wechat.'.$name))) 处 返回，服务没有被正确注册