### PR TITLE
微信授权时，减少一次重定向

### DIFF
--- a/src/Middleware/OAuthAuthenticate.php
+++ b/src/Middleware/OAuthAuthenticate.php
@@ -57,7 +57,7 @@ class OAuthAuthenticate
 
                 Event::fire(new WeChatUserAuthorized(session($sessionKey), $isNewSession, $account));
 
-                return redirect()->to($this->getTargetUrl($request));
+                return $next($request);
             }
 
             session()->forget($sessionKey);


### PR DESCRIPTION
使用中间件微信授权时，重定向了两次，后面一次重定向应该是不必要的