### PR TITLE
fix cache TTL change in Laravel 5.8

### DIFF
--- a/src/CacheBridge.php
+++ b/src/CacheBridge.php
@@ -12,6 +12,7 @@
 namespace Overtrue\LaravelWeChat;
 
 use Illuminate\Cache\Repository;
+use Illuminate\Support\Carbon;
 use Psr\SimpleCache\CacheInterface;
 
 class CacheBridge implements CacheInterface
@@ -36,7 +37,7 @@ class CacheBridge implements CacheInterface
 
     public function set($key, $value, $ttl = null)
     {
-        return $this->repository->put($key, $value, $this->toMinutes($ttl));
+        return $this->repository->put($key, $value, is_null($ttl) ? null : (new Carbon())->addSeconds($ttl));
     }
 
     public function delete($key)
@@ -62,12 +63,5 @@ class CacheBridge implements CacheInterface
     public function has($key)
     {
         return $this->repository->has($key);
-    }
-
-    protected function toMinutes($ttl = null)
-    {
-        if (!is_null($ttl)) {
-            return $ttl / 60;
-        }
     }
 }


### PR DESCRIPTION
因为 Laravel 5.8 中 Cache 的 TTL 改成了以秒为单位，根据[此文](https://laravel-news.com/cache-ttl-change-coming-to-laravel-5-8)建议，使用了：
`(new Carbon())->addSeconds($ttl)`
代替原有的 toMinutes($ttl = null)  方法并移除之。