### PR TITLE
fix: SDK 文档的链接应为 https://www.easywechat.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ $message = $event->payload; // 开放平台事件通知内容
 
 
 
-更多 SDK 的具体使用请参考：https://easywechat.com
+更多 SDK 的具体使用请参考：https://www.easywechat.com
 
 ## PHP 扩展包开发
 


### PR DESCRIPTION
https://easywechat.com 这个域名配置错误，无法访问，可以访问的地址应为 https://www.easywechat.com