### PR TITLE
使用 w7corp/easywechat 替换 overtrue/wechat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "illuminate/container": "^5.1 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "overtrue/wechat": "^5.0"
+        "w7corp/easywechat": "^5.0"
     },
     "require-dev": {
         "laravel/framework": "^8.5",


### PR DESCRIPTION
以避免 composer warning: Package overtrue/wechat is abandoned, you should avoid using it. Use w7corp/easywechat instead.